### PR TITLE
Support master exit config handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ make test
     # postconfig handler
     mruby_postconfig_handler = "handler/postconfig.rb"
 
+    # master exit config handler
+    mruby_master_exit_handler = "handler/master_exit.rb"
+
   [handler.session]
     # connection info filter handler
     mruby_connect_handler = "handler/connect.rb"

--- a/handler/master_exit.rb
+++ b/handler/master_exit.rb
@@ -1,0 +1,1 @@
+puts "master exit at eixt phase"

--- a/pmilter.conf
+++ b/pmilter.conf
@@ -14,6 +14,9 @@
     # post config handler
     mruby_postconfig_handler = "handler/postconfig.rb"
 
+    # master exit config handler
+    mruby_master_exit_handler = "handler/master_exit.rb"
+
   [handler.session]
     # connection filter handler
     mruby_connect_handler = "handler/connect.rb"

--- a/src/pmilter.h
+++ b/src/pmilter.h
@@ -109,12 +109,15 @@ typedef struct pmilter_config_t {
    * the current, highest, useful value. */
   int debug;
 
-  /* mruby_state for init phase like postconfig */
+  /* mruby_state for config phase like postconfig or master_exit*/
   mrb_state *mrb;
 
-  /* post config mruby handler */
+  /* config mruby handler */
   const char *mruby_postconfig_handler_path;
   pmilter_mrb_code *mruby_postconfig_handler;
+
+  const char *mruby_master_exit_handler_path;
+  pmilter_mrb_code *mruby_master_exit_handler;
 
   /* session mrub handlers */
   const char *mruby_connect_handler_path;

--- a/src/pmilter_config.c
+++ b/src/pmilter_config.c
@@ -226,6 +226,7 @@ static void pmilter_config_mruby_handler(pmilter_config *config, struct toml_nod
 {
   /* config handlers */
   PMILTER_CONFIG_HANDLER_CONFIG_VALUE(root, node, config, postconfig);
+  PMILTER_CONFIG_HANDLER_CONFIG_VALUE(root, node, config, master_exit);
 
   /* session handlers */
   PMILTER_SESSION_HANDLER_CONFIG_VALUE(root, node, config, connect);


### PR DESCRIPTION
 - `pmilter.conf`

```toml
[handler]
  [handler.config]
    # master exit config handler
    mruby_master_exit_handler = "handler/master_exit.rb"
```

- `handler/master_exit.rb`

```ruby
puts "master exit at eixt phase"
```

- run and exit master

```
$ make run
./pmilter -c pmilter.conf
run at postconfig phase
[Mon, 09 Jan 2017 01:28:26 GMT][notice]: pmilter/0.0.1 starting

^C
master exit at eixt phase

$ 
```
