### PR TITLE
Update typo

### DIFF
--- a/handler/master_exit.rb
+++ b/handler/master_exit.rb
@@ -1,1 +1,1 @@
-puts "master exit at eixt phase"
+puts "master exit at exit phase"


### PR DESCRIPTION
Found one minor typo:

source: `handler/master_exit.rb`

"master exit at <b>eixt</b> phase" -> "master exit at <b>exit</b> phase"